### PR TITLE
Improve shortcode 'ghcode'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .idea
+.hugo_build.lock
 *.log
 tmp/
 content-org/

--- a/layouts/shortcodes/ghcode.html
+++ b/layouts/shortcodes/ghcode.html
@@ -7,5 +7,5 @@
     {{ highlight .Content $lang }}
   {{ end }}
 {{ else }}
-  {{ errorf "Unable to get remote resource." }}
+  {{ errorf "Unable to get remote resource %q. Error position: %s" $file $.Position }}
 {{ end }}


### PR DESCRIPTION
This PR improves the shortcode `ghcode`. In case of non existing resources, the error message is now much clearer:

```
ERROR Unable to get remote resource "https://raw.githubusercontent.com/bloodstiller/ldapire/refs/heads/main/ldapChecker.py".
Error position: "/home/xxx/bloodstiller.com/content/Tools/ldapire.md:46:1"
```